### PR TITLE
pi-blaster: 32-bit target only

### DIFF
--- a/recipes-devtools/pi-blaster/pi-blaster_git.bb
+++ b/recipes-devtools/pi-blaster/pi-blaster_git.bb
@@ -16,6 +16,10 @@ INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME:${PN} = "${PN}.boot.sh"
 INITSCRIPT_PARAMS:${PN} = "defaults 15 85"
 
-COMPATIBLE_MACHINE = "^rpi$"
+# only works on 32-bit targets
+# https://github.com/sarfata/pi-blaster/issues/114
+COMPATIBLE_MACHINE = "(^$)"
+COMPATIBLE_MACHINE:armv7a = "(.*)"
+COMPATIBLE_MACHINE:armv7ve = "(.*)"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
The pi-blaster code only works on 32-bit targets.
See https://github.com/sarfata/pi-blaster/issues/114